### PR TITLE
Fixing typo on ServerStream exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ to set the log level for server streams to `warn`, `error` or `fatal` - log reco
 that are for exceptions.
 
 ```javascript
-import { createLogger, , WARN } from 'browser-bunyan';
+import { createLogger, WARN } from 'browser-bunyan';
 import { ServerStream } from '@browser-bunyan/server-stream';
 
 


### PR DESCRIPTION
Hello,

There is a typo on exemple of ServerStream exemple which cause an error.
Here is a simple change to fix it.