### PR TITLE
Fix for `flushOnClose`

### DIFF
--- a/packages/server-stream/src/index.js
+++ b/packages/server-stream/src/index.js
@@ -24,7 +24,7 @@ export class ServerStream {
         // method option must be a "POST"
         const sendBeaconSupported = 
             typeof Blob !== undefined && window.navigator.sendBeacon;
-        if(flushOnClose && sendBeaconSupported && method.toLowerCase() === 'POST') {
+        if(flushOnClose && sendBeaconSupported && method.toUpperCase() === 'POST') {
             window.addEventListener('unload', () => {
                 if(this.currentThrottleTimeout) {
                     window.clearTimeout(this.currentThrottleTimeout);


### PR DESCRIPTION
Because the `toLowerCase` method is currently used to check the method type, the `unload` event listener for `flushOnClose` is never set. As a result, `flushOnClose` option doesn't seem to work.