### PR TITLE
maintain bunyan server api

### DIFF
--- a/packages/browser-bunyan/src/util.js
+++ b/packages/browser-bunyan/src/util.js
@@ -80,7 +80,11 @@ export function format(f) {
         }
     });
     for (let x = args[i]; i < len; x = args[++i]) {
-        str += ' ' + x;
+        if (x === null || typeof (x) !== 'object') {
+            str += ' ' + x;
+        } else {
+            str += ' ' + inspect(x);
+        }
     }
     return str;
 }

--- a/packages/browser-bunyan/test/log.test.js
+++ b/packages/browser-bunyan/test/log.test.js
@@ -241,3 +241,14 @@ test('log.info(<err>)', function (t) {
     });
     t.end();
 });
+
+test('log.info(<str>, <obj>)', function (t) {
+    var obj = { hello: 'world' };
+    names.forEach(function (lvl) {
+        log3[lvl].call(log3, 'some messsage', obj);
+        var rec = catcher.records[catcher.records.length - 1];
+        t.equal(rec.msg, 'some messsage {"hello":"world"}',
+            format('log.%s msg: got %j', lvl, rec.msg));
+    });
+    t.end();
+});


### PR DESCRIPTION
currently the bunyan server api allows for the following signature: `log.method(str, obj);`  I provided the missing code snippet from the bunyan server library to enable this behavior.