### PR TITLE
Fix missing stack trace when extracting message source

### DIFF
--- a/packages/browser-bunyan/src/logger.js
+++ b/packages/browser-bunyan/src/logger.js
@@ -484,7 +484,8 @@ function mkLogEmitter(minLevel) {
                     //need to throw the error so there is a stack in IE
                     throw new Error(CALL_STACK_ERROR);
                 } catch (err) {
-                    const src = extractSrcFromStacktrace(err.stack, 2);
+                    // in Safari there is missing stack trace sometimes
+                    const src = err.stack ? extractSrcFromStacktrace(err.stack, 2) : '';
                     if (!src && !_haveWarned('src')) {
                         _warn('Unable to determine src line info', 'src');
                     }


### PR DESCRIPTION
In Safari (macOS / iOS) there are cases when `error.stack` is undefined. Browser Bunyan throws synthetic error when trying to extract source of logged message. See the code here https://github.com/philmander/browser-bunyan/blob/d9d8c44b02b4b72c184a7096eaf40e7da158ca50/packages/browser-bunyan/src/logger.js#L487 But it fails because `err.stack` is undefined.

Reproduced in Safari 12.1 (macOS) and iOS Safari 12.3.1.
