### PR TITLE
fix: Export built-in streams in main typings. Fixes #48

### DIFF
--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -1,7 +1,12 @@
-import { createLogger, INFO, DEBUG, WARN, stdSerializers, resolveLevel } from 'browser-bunyan';
-import { ConsoleFormattedStream } from '@browser-bunyan/console-formatted-stream';
-import { ConsolePlainStream } from '@browser-bunyan/console-plain-stream';
-import { ConsoleRawStream } from '@browser-bunyan/console-raw-stream';
+import {
+    createLogger,
+    INFO, DEBUG, WARN,
+    stdSerializers,
+    resolveLevel,
+    ConsoleRawStream,
+    ConsoleFormattedStream,
+    ConsolePlainStream,
+} from 'browser-bunyan';
 
 const log = createLogger({
     name: 'myLogger',

--- a/packages/browser-bunyan/src/index.d.ts
+++ b/packages/browser-bunyan/src/index.d.ts
@@ -70,3 +70,8 @@ export type StdSerializers = {
 export * from '@browser-bunyan/levels';
 export function createLogger(opts: LoggerOptions): Logger;
 export const stdSerializers: StdSerializers;
+export function safeCycles(): any;
+
+export * from '@browser-bunyan/console-plain-stream';
+export * from '@browser-bunyan/console-raw-stream';
+export * from '@browser-bunyan/console-formatted-stream';


### PR DESCRIPTION
Now the following will compile:

```ts
import {
    ConsoleRawStream,
    ConsoleFormattedStream,
    ConsolePlainStream,
} from 'browser-bunyan';
```