### PR TITLE
Improve type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,24 @@ All loggers must provide a "name". This is somewhat akin to the log4j logger
     {"name":"myapp","hostname":"banana.local","pid":40161,"level":40,"lang":"fr","msg":"au revoir","time":"2013-01-04T18:46:23.853Z","v":0}
 ```
 
+## Constructor API
+
+```javascript
+const { createLogger } = require('browser-bunyan');
+const log = createLogger({
+    name: <string>,                     // Required
+    level: <level constant or string>,  // Optional, see "Levels" section
+    stream: <LogStream>,                // Optional, see "Streams" section
+    streams: <StreamOptions[]>          // Optional, see "Streams" section
+    serializers: <serializers mapping>, // Optional, see "Serializers" section
+    src: <boolean>,                     // Optional, see "Core fields" section
+
+    // Any other fields are added to all log records as is.
+    foo: 'bar',
+    ...
+});
+```
+
 ### Log Method API
 
 The example above shows two different ways to call `log.info(...)`. The

--- a/packages/browser-bunyan/src/index.d.ts
+++ b/packages/browser-bunyan/src/index.d.ts
@@ -7,12 +7,17 @@ type LoggerOptions = {
     src?: boolean,
     stream?: LogStream,
     level?: string | number,
-    [key: string]: any;
+    [key: string]: any
 }
 
 type ChildLoggerOptions = {
-    childName?: string;
-    [key: string]: any;
+    childName?: string
+    streams?: Array<StreamOptions>,
+    serializers?: Object,
+    src?: boolean,
+    stream?: LogStream,
+    level?: string | number,
+    [key: string]: any
 }
 
 type StreamOptions = {

--- a/packages/browser-bunyan/src/index.d.ts
+++ b/packages/browser-bunyan/src/index.d.ts
@@ -7,6 +7,12 @@ type LoggerOptions = {
     src?: boolean,
     stream?: LogStream,
     level?: string | number,
+    [key: string]: any;
+}
+
+type ChildLoggerOptions = {
+    childName?: string;
+    [key: string]: any;
 }
 
 type StreamOptions = {
@@ -14,53 +20,53 @@ type StreamOptions = {
     stream: LogStream,
 }
 
-interface Logger {
-    addStream(): void,
-    addSerializers(): void,
-    child(options?: LoggerOptions, simple?: boolean): Logger,
+export declare class Logger {
+    addStream(): void;
+    addSerializers(): void;
+    child(options?: ChildLoggerOptions, simple?: boolean): Logger;
 
-    level(level: string | number): void,
-    level(): number,
+    level(level: string | number): void;
+    level(): number;
 
-    levels(stream: string | number, level: string | number): void,
-    levels(stream: string): number,
-    levels(): Array<number>,
+    levels(stream: string | number, level: string | number): void;
+    levels(stream: string): number;
+    levels(): Array<number>;
 
     // trace
-    trace(fields: object, msg: string, ...args: any[]): void,
-    trace(err: Error, msg: string, ...args: any[]): void,
-    trace(msg: string, ...args: any[]): void,
-    trace(): boolean,
+    trace(fields: object, msg: string, ...args: any[]): void;
+    trace(err: Error, msg: string, ...args: any[]): void;
+    trace(msg: string, ...args: any[]): void;
+    trace(): boolean;
 
     // debug
-    debug(fields: object, msg: string, ...args: any[]): void,
-    debug(err: Error, msg: string, ...args: any[]): void,
-    debug(msg: string, ...args: any[]): void,
-    debug(): boolean,
+    debug(fields: object, msg: string, ...args: any[]): void;
+    debug(err: Error, msg: string, ...args: any[]): void;
+    debug(msg: string, ...args: any[]): void;
+    debug(): boolean;
 
     // info
-    info(fields: object, msg: string, ...args: any[]): void,
-    info(err: Error, msg: string, ...args: any[]): void,
-    info(msg: string, ...args: any[]): void,
-    info(): boolean,
+    info(fields: object, msg: string, ...args: any[]): void;
+    info(err: Error, msg: string, ...args: any[]): void;
+    info(msg: string, ...args: any[]): void;
+    info(): boolean;
 
     // warn
-    warn(fields: object, msg: string, ...args: any[]): void,
-    warn(err: Error, msg: string, ...args: any[]): void,
-    warn(msg: string, ...args: any[]): void,
-    warn(): boolean,
+    warn(fields: object, msg: string, ...args: any[]): void;
+    warn(err: Error, msg: string, ...args: any[]): void;
+    warn(msg: string, ...args: any[]): void;
+    warn(): boolean;
 
     // error
-    error(fields: object, msg: string, ...args: any[]): void,
-    error(err: Error, msg: string, ...args: any[]): void,
-    error(msg: string, ...args: any[]): void,
-    error(): boolean,
+    error(fields: object, msg: string, ...args: any[]): void;
+    error(err: Error, msg: string, ...args: any[]): void;
+    error(msg: string, ...args: any[]): void;
+    error(): boolean;
 
     // fatal
-    fatal(fields: object, msg: string, ...args: any[]): void,
-    fatal(err: Error, msg: string, ...args: any[]): void,
-    fatal(msg: string, ...args: any[]): void,
-    fatal(): boolean,
+    fatal(fields: object, msg: string, ...args: any[]): void;
+    fatal(err: Error, msg: string, ...args: any[]): void;
+    fatal(msg: string, ...args: any[]): void;
+    fatal(): boolean;
 }
 
 export type StdSerializers = {


### PR DESCRIPTION
Hey there and thanks for a really useful package!

I'd like to propose a few changes to the type definitions of the main package. These would allow the package to better integrate in TypeScript projects.

`
type LoggerOptions = {
    ....
    [key: string]: any;
}
`

Allows any additional properties to be added to the logged object as documented [here](https://github.com/trentm/node-bunyan#constructor-api) in node-bunyan. As this also works for browser-buynan I added the respective documentation from node-bunyan.

The definition for the first argument for Logger#child is wrong, as it doesn't expect LoggerOptions. Actually it expects LoggerOptions without the name property and an optional childName property and again any other additional properties. Here I added the type ChildLoggerOptions and referenced it as the type for the first argument of Logger#child

Lastly I turned the interface for Logger into an exported class declaration, as it's actually a class that's exported from the module. 

These should not be a breaking changes.

Best regards
Simon