### PR TITLE
Name must not be passed to child()

### DIFF
--- a/packages/browser-bunyan/src/index.d.ts
+++ b/packages/browser-bunyan/src/index.d.ts
@@ -17,7 +17,7 @@ type StreamOptions = {
 interface Logger {
     addStream(): void,
     addSerializers(): void,
-    child(options?: LoggerOptions, simple?: boolean): Logger,
+    child(options?: Omit<LoggerOptions, 'name'>, simple?: boolean): Logger,
 
     level(level: string | number): void,
     level(): number,


### PR DESCRIPTION
If you call `child` the typescript types require `name` to be provided if you provide an options object, but if you provide a name you get an error.