### PR TITLE
Use levelName from rec instead of calculating from level

### DIFF
--- a/packages/console-formatted-stream/src/index.js
+++ b/packages/console-formatted-stream/src/index.js
@@ -1,4 +1,4 @@
-import { TRACE, DEBUG, INFO, WARN, ERROR, FATAL, nameFromLevel } from '@browser-bunyan/levels';
+import { TRACE, DEBUG, INFO, WARN, ERROR, FATAL } from '@browser-bunyan/levels';
 const DEFAULT_CSS = {
     levels: {
         trace: 'color: DeepPink',
@@ -29,7 +29,7 @@ export class ConsoleFormattedStream {
         const loggerName = rec.childName ? rec.name + '/' + rec.childName : rec.name;
 
         //get level name and pad start with spacs
-        let levelName = nameFromLevel[rec.level];
+        let levelName = rec.levelName || 'info';
         const formattedLevelName = (Array(6 - levelName.length).join(' ') + levelName).toUpperCase();
 
         if (this.logByLevel) {


### PR DESCRIPTION
It looks like browser-bunyan provides `levelName` with the record so it's not necessary for the formater to calculate that itself.